### PR TITLE
Add support for sprig functions in Go templates in the format argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ Accepting comments from `stdin` allows using Unix pipes to send the output from 
     terraform plan 2>&1 | github-commenter -format "Output from `terraform plan`<br/>```{{.}}```"
 ```
 
+__NOTE__: The module supports [sprig functions](http://masterminds.github.io/sprig/) in `Go` templates, allowing to use string replacement and Regular Expressions in the `format` argument.
+
+See [string functions](http://masterminds.github.io/sprig/strings.html) for more details.
+
+For example:
+
+```sh
+GITHUB_COMMENT_FORMAT="Helm diff:<br><br><pre>{{regexReplaceAllLiteral `\\n` . `<br>` }}<pre>"
+```
+
 
 
 
@@ -170,7 +180,7 @@ export GITHUB_OWNER=cloudposse
 export GITHUB_REPO=github-commenter
 export GITHUB_COMMENT_TYPE=pr
 export GITHUB_PR_ISSUE_NUMBER=1
-export GITHUB_COMMENT_FORMAT="My comment:<br/>{{.}}"
+export GITHUB_COMMENT_FORMAT="Helm diff:<br><br><pre>{{regexReplaceAllLiteral `\\n` . `<br>` }}<pre>"
 export GITHUB_COMMENT="+1 LGTM"
 
 docker run -i --rm \

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ export GITHUB_REPO=github-commenter
 export GITHUB_COMMENT_TYPE=pr
 export GITHUB_PR_ISSUE_NUMBER=1
 export GITHUB_COMMENT_FORMAT="Helm diff:<br><br><pre>{{regexReplaceAllLiteral `\\n` . `<br>` }}<pre>"
-export GITHUB_COMMENT="+1 LGTM"
+export GITHUB_COMMENT="Helm diff comment"
 
 docker run -i --rm \
         -e GITHUB_TOKEN \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GitHub API supports these types of comments:
 
 Since GitHub considers Pull Requests as Issues, `Comments on Issues` and `Comments on Pull Requests` use the same API.
 
-The module supports all of these types of comments (type: `commit`, `pr-review`, `pr-file`, `issue`, `pr`).
+The utility supports all these types of comments (`commit`, `pr-review`, `pr-file`, `issue`, `pr`).
 
 
 ---
@@ -58,7 +58,7 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 __NOTE__: Create a [GitHub token](https://help.github.com/articles/creating-an-access-token-for-command-line-use) with `repo:status` and `public_repo` scopes.
 
-__NOTE__: The module accepts parameters as command-line arguments or as ENV variables (or any combination of command-line arguments and ENV vars).
+__NOTE__: The utility accepts parameters as command-line arguments or as ENV variables (or any combination of command-line arguments and ENV vars).
 Command-line arguments take precedence over ENV vars.
 
 
@@ -77,9 +77,9 @@ Command-line arguments take precedence over ENV vars.
 | delete-comment-regex  | GITHUB_DELETE_COMMENT_REGEX  | Regex to find previous comments to delete before creating the new comment. Supported for comment types `commit`, `pr-file`, `issue` and `pr` |
 
 
-__NOTE__: The module accepts the text of the comment from the command-line argument `comment`, from the ENV variable `GITHUB_COMMENT`, or from the standard input.
+__NOTE__: The utility accepts the text of the comment from the command-line argument `comment`, from the ENV variable `GITHUB_COMMENT`, or from the standard input.
 Command-line argument takes precedence over ENV var, and ENV var takes precedence over standard input.
-Accepting comments from `stdin` allows using Unix pipes to send the output from another program as the input to the module:
+Accepting comments from `stdin` allows using Unix pipes to send the output from another program as the input to the tool:
 
 ```sh
     cat comment.txt | github-commenter ...
@@ -89,7 +89,7 @@ Accepting comments from `stdin` allows using Unix pipes to send the output from 
     terraform plan 2>&1 | github-commenter -format "Output from `terraform plan`<br/>```{{.}}```"
 ```
 
-__NOTE__: The module supports [sprig functions](http://masterminds.github.io/sprig/) in `Go` templates, allowing to use string replacement and Regular Expressions in the `format` argument.
+__NOTE__: The utility supports [sprig functions](http://masterminds.github.io/sprig/) in `Go` templates, allowing to use string replacement and Regular Expressions in the `format` argument.
 
 See [string functions](http://masterminds.github.io/sprig/strings.html) for more details.
 
@@ -104,7 +104,7 @@ GITHUB_COMMENT_FORMAT="Helm diff:<br><br><pre>{{regexReplaceAllLiteral `\\n` . `
 
 ## Examples
 
-The module can be called directly or as a Docker container.
+The utility can be called directly or as a Docker container.
 
 ### Build the Go program locally
 

--- a/README.yaml
+++ b/README.yaml
@@ -92,6 +92,16 @@ usage: |-
       terraform plan 2>&1 | github-commenter -format "Output from `terraform plan`<br/>```{{.}}```"
   ```
 
+  __NOTE__: The module supports [sprig functions](http://masterminds.github.io/sprig/) in `Go` templates, allowing to use string replacement and Regular Expressions in the `format` argument.
+
+  See [string functions](http://masterminds.github.io/sprig/strings.html) for more details.
+
+  For example:
+
+  ```sh
+  GITHUB_COMMENT_FORMAT="Helm diff:<br><br><pre>{{regexReplaceAllLiteral `\\n` . `<br>` }}<pre>"
+  ```
+
 examples: |-
   The module can be called directly or as a Docker container.
 
@@ -169,7 +179,7 @@ examples: |-
   export GITHUB_REPO=github-commenter
   export GITHUB_COMMENT_TYPE=pr
   export GITHUB_PR_ISSUE_NUMBER=1
-  export GITHUB_COMMENT_FORMAT="My comment:<br/>{{.}}"
+  export GITHUB_COMMENT_FORMAT="Helm diff:<br><br><pre>{{regexReplaceAllLiteral `\\n` . `<br>` }}<pre>"
   export GITHUB_COMMENT="+1 LGTM"
 
   docker run -i --rm \

--- a/README.yaml
+++ b/README.yaml
@@ -42,7 +42,7 @@ description: |-
 
   Since GitHub considers Pull Requests as Issues, `Comments on Issues` and `Comments on Pull Requests` use the same API.
 
-  The module supports all of these types of comments (type: `commit`, `pr-review`, `pr-file`, `issue`, `pr`).
+  The utility supports all these types of comments (`commit`, `pr-review`, `pr-file`, `issue`, `pr`).
 
 related:
   - name: "github-status-updater"
@@ -61,7 +61,7 @@ screenshots:
 usage: |-
   __NOTE__: Create a [GitHub token](https://help.github.com/articles/creating-an-access-token-for-command-line-use) with `repo:status` and `public_repo` scopes.
 
-  __NOTE__: The module accepts parameters as command-line arguments or as ENV variables (or any combination of command-line arguments and ENV vars).
+  __NOTE__: The utility accepts parameters as command-line arguments or as ENV variables (or any combination of command-line arguments and ENV vars).
   Command-line arguments take precedence over ENV vars.
 
 
@@ -80,9 +80,9 @@ usage: |-
   | delete-comment-regex  | GITHUB_DELETE_COMMENT_REGEX  | Regex to find previous comments to delete before creating the new comment. Supported for comment types `commit`, `pr-file`, `issue` and `pr` |
 
 
-  __NOTE__: The module accepts the text of the comment from the command-line argument `comment`, from the ENV variable `GITHUB_COMMENT`, or from the standard input.
+  __NOTE__: The utility accepts the text of the comment from the command-line argument `comment`, from the ENV variable `GITHUB_COMMENT`, or from the standard input.
   Command-line argument takes precedence over ENV var, and ENV var takes precedence over standard input.
-  Accepting comments from `stdin` allows using Unix pipes to send the output from another program as the input to the module:
+  Accepting comments from `stdin` allows using Unix pipes to send the output from another program as the input to the tool:
 
   ```sh
       cat comment.txt | github-commenter ...
@@ -92,7 +92,7 @@ usage: |-
       terraform plan 2>&1 | github-commenter -format "Output from `terraform plan`<br/>```{{.}}```"
   ```
 
-  __NOTE__: The module supports [sprig functions](http://masterminds.github.io/sprig/) in `Go` templates, allowing to use string replacement and Regular Expressions in the `format` argument.
+  __NOTE__: The utility supports [sprig functions](http://masterminds.github.io/sprig/) in `Go` templates, allowing to use string replacement and Regular Expressions in the `format` argument.
 
   See [string functions](http://masterminds.github.io/sprig/strings.html) for more details.
 
@@ -103,7 +103,7 @@ usage: |-
   ```
 
 examples: |-
-  The module can be called directly or as a Docker container.
+  The utility can be called directly or as a Docker container.
 
   ### Build the Go program locally
 

--- a/README.yaml
+++ b/README.yaml
@@ -180,7 +180,7 @@ examples: |-
   export GITHUB_COMMENT_TYPE=pr
   export GITHUB_PR_ISSUE_NUMBER=1
   export GITHUB_COMMENT_FORMAT="Helm diff:<br><br><pre>{{regexReplaceAllLiteral `\\n` . `<br>` }}<pre>"
-  export GITHUB_COMMENT="+1 LGTM"
+  export GITHUB_COMMENT="Helm diff comment"
 
   docker run -i --rm \
           -e GITHUB_TOKEN \

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,3 +2,4 @@ package: github.com/cloudposse/github-commenter
 import:
   - package: github.com/google/go-github/github
   - package: golang.org/x/net/context
+  - package: github.com/Masterminds/sprig

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"github.com/Masterminds/sprig"
 	"github.com/google/go-github/github"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -95,7 +96,7 @@ func formatComment(comment string) (string, error) {
 		return comment, nil
 	}
 
-	t, err := template.New("formatComment").Parse(*format)
+	t, err := template.New("formatComment").Funcs(sprig.TxtFuncMap()).Parse(*format)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## what
* Add support for `sprig` functions in Go templates in the `format` argument

## why
* To be able to manipulate the text of the comments using various functions in `Go` templates, in particular string replacement and Regular Expressions

```
GITHUB_COMMENT_FORMAT="Helm diff:<br><br><pre>{{regexReplaceAllLiteral `\\n` . `<br>` }}<pre>"
```

## references
* http://masterminds.github.io/sprig/
* http://masterminds.github.io/sprig/strings.html
* https://github.com/Masterminds/sprig
