### PR TITLE
Fix `template_file`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Cloud Posse, LLC
+   Copyright 2018-2019 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"regexp"
 	"strconv"
 	"text/template"
@@ -105,23 +106,24 @@ func formatComment(comment string) (string, error) {
 	var templateFileFinal string
 
 	if *format != "" || *templ != "" {
-		t = template.New("formatComment").Funcs(sprig.TxtFuncMap())
 		if *templ != "" {
 			templateFinal = *templ
 		} else {
 			templateFinal = *format
 		}
+		t = template.New("formatComment").Funcs(sprig.TxtFuncMap())
 		t, err = t.Parse(templateFinal)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		t = template.New("formatComment").Funcs(sprig.TxtFuncMap())
 		if *templateFile != "" {
 			templateFileFinal = *templateFile
 		} else {
 			templateFileFinal = *formatFile
 		}
+		name := path.Base(templateFileFinal)
+		t = template.New(name).Funcs(sprig.TxtFuncMap())
 		t, err = t.ParseFiles(templateFileFinal)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
## what
* Fix `template_file`

## why
* When a template is read from a file, the template name must be the name of the file

