### PR TITLE
Add GHE functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Command-line arguments take precedence over ENV vars.
 | format_file           | GITHUB_COMMENT_FORMAT_FILE   | Alias of `template_file`                                                                                                                                                          |
 | comment               | GITHUB_COMMENT               | Comment text. If neither `comment` nor `GITHUB_COMMENT` provided, will read from `stdin`                                                                                          |
 | delete-comment-regex  | GITHUB_DELETE_COMMENT_REGEX  | Regex to find previous comments to delete before creating the new comment. Supported for comment types `commit`, `pr-file`, `issue` and `pr`                                      |
+| baseURL               | GITHUB_BASE_URL              | Github Enterprise URL. _E.g._ `https://github.example.com/api/v3`                                                                                                                 |
+| uploadURL             | GITHUB_UPLOAD_URL            | Github Enterprise Upload URL to pass to the Github client                                                                                                                         |
+| insecure              | GITHUB_INSECURE              | Boolean to ignore SSL certificate check                                                                                                                                           | 
 
 
 __NOTE__: The utility accepts the text of the comment from the command-line argument `comment`, from the ENV variable `GITHUB_COMMENT`, or from the standard input.

--- a/README.yaml
+++ b/README.yaml
@@ -84,6 +84,9 @@ usage: |-
   | format_file           | GITHUB_COMMENT_FORMAT_FILE   | Alias of `template_file`                                                                                                                                                          |
   | comment               | GITHUB_COMMENT               | Comment text. If neither `comment` nor `GITHUB_COMMENT` provided, will read from `stdin`                                                                                          |
   | delete-comment-regex  | GITHUB_DELETE_COMMENT_REGEX  | Regex to find previous comments to delete before creating the new comment. Supported for comment types `commit`, `pr-file`, `issue` and `pr`                                      |
+  | baseURL               | GITHUB_BASE_URL              | Github Enterprise URL. _E.g._ `https://github.example.com/api/v3`                                                                                                                 |
+  | uploadURL             | GITHUB_UPLOAD_URL            | Github Enterprise Upload URL to pass to the Github client                                                                                                                         |
+  | insecure              | GITHUB_INSECURE              | Boolean to ignore SSL certificate check                                                                                                                                           | 
 
 
   __NOTE__: The utility accepts the text of the comment from the command-line argument `comment`, from the ENV variable `GITHUB_COMMENT`, or from the standard input.

--- a/main.go
+++ b/main.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"flag"
 	"fmt"
-	"github.com/Masterminds/sprig"
-	"github.com/google/go-github/github"
-	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -15,16 +12,24 @@ import (
 	"path"
 	"regexp"
 	"strconv"
+	"strings"
 	"text/template"
+
+	"github.com/Masterminds/sprig"
+	"github.com/google/go-github/github"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 type roundTripper struct {
 	accessToken string
+	insecure    bool
 }
 
 func (rt roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	r.Header.Set("Authorization", fmt.Sprintf("token %s", rt.accessToken))
-	return http.DefaultTransport.RoundTrip(r)
+	transport := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: rt.insecure}}
+	return transport.RoundTrip(r)
 }
 
 var (
@@ -42,6 +47,9 @@ var (
 	formatFile         = flag.String("format_file", os.Getenv("GITHUB_COMMENT_FORMAT_FILE"), "Alias of `template_file`")
 	comment            = flag.String("comment", os.Getenv("GITHUB_COMMENT"), "Comment text")
 	deleteCommentRegex = flag.String("delete-comment-regex", os.Getenv("GITHUB_DELETE_COMMENT_REGEX"), "Regex to find previous comments to delete before creating the new comment. Supported for comment types `commit`, `pr-file`, `issue` and `pr`")
+	baseURL            = flag.String("baseURL", os.Getenv("GITHUB_BASE_URL"), "Base URL of github enterprise")
+	uploadURL          = flag.String("uploadURL", os.Getenv("GITHUB_UPLOAD_URL"), "Upload URL of github enterprise")
+	insecure           = flag.Bool("insecure", strings.ToLower(os.Getenv("GITHUB_INSECURE")) == "true", "Ignore SSL certificate check")
 )
 
 func getPullRequestOrIssueNumber(str string) (int, error) {
@@ -158,8 +166,21 @@ func main() {
 		log.Fatal("-type or GITHUB_COMMENT_TYPE must be one of 'commit', 'pr', 'issue', 'pr-review' or 'pr-file'")
 	}
 
-	http.DefaultClient.Transport = roundTripper{*token}
-	githubClient := github.NewClient(http.DefaultClient)
+	http.DefaultClient.Transport = roundTripper{*token, *insecure}
+	var githubClient *github.Client
+	if *baseURL != "" || *uploadURL != "" {
+		if *baseURL == "" {
+			flag.PrintDefaults()
+			log.Fatal("-baseURL or GITHUB_BASE_URL required when using -uploadURL or GITHUB_UPLOAD_URL")
+		}
+		if *uploadURL == "" {
+			flag.PrintDefaults()
+			log.Fatal("-uploadURL or GITHUB_UPLOAD_URL required when using -baseURL or GITHUB_BASE_URL")
+		}
+		githubClient, _ = github.NewEnterpriseClient(*baseURL, *uploadURL, http.DefaultClient)
+	} else {
+		githubClient = github.NewClient(http.DefaultClient)
+	}
 
 	// https://developer.github.com/v3/guides/working-with-comments
 	// https://developer.github.com/v3/repos/comments

--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		log.Println("github-commenter: Created GitHub Commit comment", commitComment.ID)
+		log.Println("github-commenter: Created GitHub Commit comment", *commitComment.ID)
 	} else if *commentType == "pr-review" {
 		// https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
 		num, err := getPullRequestOrIssueNumber(*number)
@@ -255,7 +255,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		log.Println("github-commenter: Created GitHub PR Review comment", pullRequestReview.ID)
+		log.Println("github-commenter: Created GitHub PR Review comment", *pullRequestReview.ID)
 	} else if *commentType == "issue" || *commentType == "pr" {
 		// https://developer.github.com/v3/issues/comments
 		num, err := getPullRequestOrIssueNumber(*number)
@@ -304,7 +304,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		log.Println("github-commenter: Created GitHub Issue comment", issueComment.ID)
+		log.Println("github-commenter: Created GitHub Issue comment", *issueComment.ID)
 	} else if *commentType == "pr-file" {
 		// https://developer.github.com/v3/pulls/comments
 		num, err := getPullRequestOrIssueNumber(*number)
@@ -368,6 +368,6 @@ func main() {
 			log.Fatal(err)
 		}
 
-		log.Println("github-commenter: Created GitHub PR comment on file: ", pullRequestComment.ID)
+		log.Println("github-commenter: Created GitHub PR comment on file: ", *pullRequestComment.ID)
 	}
 }


### PR DESCRIPTION
## what
Adds Github Enterprise functionality

## why
So we can use the awesome github-commenter with GHE.

## testing
Running the thing now returns the comment ID rather than memory address:

```
2020/07/06 13:30:44 github-commenter: Created GitHub Issue comment 404233
```
vs
```
2020/07/06 12:59:02 github-commenter: Created GitHub Issue comment 0xc00009e130
```

Comment successfully posted to a GHE PR:
![Screenshot 2020-07-06 at 13 45 49](https://user-images.githubusercontent.com/3025844/86594860-a8b6c400-bf8f-11ea-9090-1d71b45bcfbd.png)
