### PR TITLE
Adding configuration support proxy from environment variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,11 @@ type roundTripper struct {
 
 func (rt roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	r.Header.Set("Authorization", fmt.Sprintf("token %s", rt.accessToken))
-	transport := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: rt.insecure}}
+
+	transport := http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: rt.insecure},
+	}
 	return transport.RoundTrip(r)
 }
 


### PR DESCRIPTION
Updating the http.Transport configuration to load proxy settings from the environment.
This is usually required in Enterprise environments when traffic to GHE might be allowed only via corporate proxies.

I've performed the following testing:

- Execution without environment variable setup (Status quo maintained) ==> Created issue comment https://github.com/sandrogattuso/github-commenter/pull/1#issuecomment-798806804
- Execution with `HTTPS_PROXY` set to `http://localhost:3128` --> Received proxyconnect tcp: dial tcp [::1]:3128: connect: connection refused (I don't have a local proxy setup just wanted to validate the call goes via the configured endpoint)
- Execution with `HTTPS_PROXY` set to `http://localhost:3128`  and `NO_PROXY` set to `.github.com` ==> Created Issue comment https://github.com/sandrogattuso/github-commenter/pull/1#issuecomment-798807074