### PR TITLE
Update artifact actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,14 +40,14 @@ jobs:
           OUTPUT_PATH: ${{ github.workspace }}/release/${{ github.event.repository.name }}_
       # Upload artifacts for this build
       - name: 'Upload artifacts'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}
           path: ${{ github.workspace }}/release/*
       # Attach Go binaries to GitHub Release
       - name: 'Attach artifacts to GitHub Release'
         if: ${{ github.event_name == 'release' }}
-        uses: cloudposse/actions/github/release-assets@0.15.0
+        uses: cloudposse/actions/github/release-assets@0.31.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_PATH: ${{ github.workspace }}/release/${{ github.event.repository.name }}_*

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v3
-    - uses: mszostok/codeowners-validator@v0.7.4
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:


### PR DESCRIPTION
## what
- Update `go` workflow to use current artifact uploader and attachers
- Rollback `mszostok/codeowners-validator` version 0.7.4 to 0.7.1

## why
- Old versions have become unreliable
- `mszostok/codeowners-validator` 0.7.4 has an issue with the `PUBLIC_REPO_ACCESS_TOKEN`