### PR TITLE
support arm64 linux, windows, darwin 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
 
-  pull_request: 
+  pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -21,22 +21,12 @@ jobs:
           GO111MODULE: on
           # Architectures to build for
           GOX_OSARCH: >-
-            windows/386
             windows/amd64
-            freebsd/arm
-            netbsd/386
-            netbsd/amd64
-            netbsd/arm
-            linux/s390x
-            linux/arm
-            darwin/386
-            darwin/amd64
-            linux/386
+            windows/arm64
             linux/amd64
-            freebsd/amd64
-            freebsd/386
-            openbsd/386
-            openbsd/amd64
+            linux/arm64
+            darwin/amd64
+            darwin/arm64
           OUTPUT_PATH: ${{ github.workspace }}/release/${{ github.event.repository.name }}_
       # Upload artifacts for this build
       - name: 'Upload artifacts'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
       # Build Go binaries
       - name: 'Build Go binaries'
-        uses: cloudposse/actions/go/build@0.15.0
+        uses: cloudposse/actions/go/build@0.33.0
         env:
           GO111MODULE: on
           # Architectures to build for

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,12 +21,25 @@ jobs:
           GO111MODULE: on
           # Architectures to build for
           GOX_OSARCH: >-
-            windows/amd64
-            windows/arm64
-            linux/amd64
-            linux/arm64
+            darwin/386
             darwin/amd64
             darwin/arm64
+            freebsd/386
+            freebsd/amd64
+            freebsd/arm
+            linux/386
+            linux/amd64
+            linux/arm
+            linux/arm64
+            linux/s390x
+            netbsd/386
+            netbsd/amd64
+            netbsd/arm
+            openbsd/386
+            openbsd/amd64
+            windows/386
+            windows/amd64
+            windows/arm64
           OUTPUT_PATH: ${{ github.workspace }}/release/${{ github.event.repository.name }}_
       # Upload artifacts for this build
       - name: 'Upload artifacts'


### PR DESCRIPTION
## what
* mainly just need linux_arm64 but it makes sense to provide amd64+arm64 for all three big OS

## why
* trying to make geodesic on arm64 better