### PR TITLE
Update github output syntax

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
         if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
           TAGS="$TAGS,${{ github.repository }}:latest"
         fi
-        echo ::set-output name=tags::${TAGS}
+        echo "tags=${TAGS}" >> $GITHUB_OUTPUT
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/