### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,13 @@ jobs:
     steps:
       # Checkout the repo
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       # Setup Go
       - name: 'Setup Go'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.19'
 
@@ -32,7 +32,7 @@ jobs:
       # Build and release
       - name: Build release
         if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && github.ref_name == 'master')
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: latest
@@ -43,7 +43,7 @@ jobs:
       # Trial build
       - name: Test build
         if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref_name != 'master')
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout source code at current commit"
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Prepare tags for Docker image
       if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
       id: prepare
@@ -29,12 +29,12 @@ jobs:
         fi
         echo "tags=${TAGS}" >> $GITHUB_OUTPUT
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
     - name: Login to DockerHub
       if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
-      uses: docker/login-action@v3
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout source code at current commit"
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -4,27 +4,12 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  validate-codeowners:
-    runs-on: ubuntu-latest
-    steps:
-    - name: "Checkout source code at current commit"
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
-    - uses: mszostok/codeowners-validator@v0.7.1
-      if: github.event.pull_request.head.repo.full_name == github.repository
-      name: "Full check of CODEOWNERS"
-      with:
-        # For now, remove "files" check to allow CODEOWNERS to specify non-existent
-        # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
-        #   checks: "files,syntax,owners,duppatterns"
-        checks: "syntax,owners,duppatterns"
-        owner_checker_allow_unowned_patterns: "false"
-        # GitHub access token is required only if the `owners` check is enabled
-        github_access_token: "${{ secrets.REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.7.1
-      if: github.event.pull_request.head.repo.full_name != github.repository
-      name: "Syntax check of CODEOWNERS"
-      with:
-        checks: "syntax,duppatterns"
-        owner_checker_allow_unowned_patterns: "false"
+  ci-codeowners:
+    uses: cloudposse/.github/.github/workflows/shared-codeowners.yml@main
+    with:
+      is_fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+    secrets: inherit

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 # Visit https://goreleaser.com for documentation on how to customize this behavior.
 
 before:
@@ -31,7 +33,7 @@ builds:
       - '-s -w'
 
 archives:
-  - format: binary
+  - formats: [binary]
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 
 checksum:
@@ -43,4 +45,4 @@ release:
 # draft: true
 
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows to versions running on the Node 24 runtime,
  SHA-pinned with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `actions/setup-go@v5` → `@b7ad1dad...` `# v7.0.0`
  * `docker/login-action@v3` → `@dbcb8138...` `# v4.6.0`
  * `docker/setup-buildx-action@v3` → `@bb05f3f5...` `# v4.2.0`
  * `docker/setup-qemu-action@v3` → `@96fe6ef7...` `# v4.2.0`
  * `goreleaser/goreleaser-action@v5` → `@f06c13b6...` `# v7.2.3`

Supersedes #136
Supersedes #135
Supersedes #134
Supersedes #132
Supersedes #130
Supersedes #128

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## still on Node 20

* `docker/build-push-action@v7` — already on the Node 24 major, left as a floating tag (not
  covered by this mechanical pin pass)
* `mszostok/codeowners-validator@v0.7.1` — Docker-based action, not affected by the Node runtime
  deprecation
* `cloudposse/.github/.github/workflows/shared-auto-release.yml@main` — reusable workflow ref,
  intentionally left on `@main`
